### PR TITLE
feat: Added the VertexAiResourceNoun.to_dict() method 

### DIFF
--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -44,6 +44,7 @@ from google.auth import credentials as auth_credentials
 from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import utils
 from google.cloud.aiplatform.compat.types import encryption_spec as gca_encryption_spec
+from google.protobuf import json_format
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 
@@ -606,6 +607,10 @@ class VertexAiResourceNoun(metaclass=abc.ABCMeta):
 
     def __repr__(self) -> str:
         return f"{object.__repr__(self)} \nresource name: {self.resource_name}"
+
+    def to_dict(self) -> dict:
+        """Returns the resource proto as a dictionary."""
+        return json_format.MessageToDict(self.gca_resource._pb)
 
 
 def optional_sync(

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -608,7 +608,7 @@ class VertexAiResourceNoun(metaclass=abc.ABCMeta):
     def __repr__(self) -> str:
         return f"{object.__repr__(self)} \nresource name: {self.resource_name}"
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> Dict[str, Any]:
         """Returns the resource proto as a dictionary."""
         return json_format.MessageToDict(self.gca_resource._pb)
 

--- a/google/cloud/aiplatform/metadata/resource.py
+++ b/google/cloud/aiplatform/metadata/resource.py
@@ -98,7 +98,7 @@ class _Resource(base.VertexAiResourceNounWithFutureManager, abc.ABC):
 
     @property
     def metadata(self) -> Dict:
-        return json_format.MessageToDict(self._gca_resource._pb)["metadata"]
+        return self.to_dict()["metadata"]
 
     @property
     def schema_title(self) -> str:

--- a/google/cloud/aiplatform/metadata/resource.py
+++ b/google/cloud/aiplatform/metadata/resource.py
@@ -24,7 +24,6 @@ from typing import Optional, Dict, Union, Sequence
 import proto
 from google.api_core import exceptions
 from google.auth import credentials as auth_credentials
-from google.protobuf import json_format
 
 from google.cloud.aiplatform import base, initializer
 from google.cloud.aiplatform import utils

--- a/tests/system/aiplatform/test_dataset.py
+++ b/tests/system/aiplatform/test_dataset.py
@@ -239,16 +239,15 @@ class TestDataset:
             gcs_source=[_TEST_TABULAR_CLASSIFICATION_GCS_SOURCE],
         )
 
-        gapic_dataset = tabular_dataset._gca_resource
         shared_state["dataset_name"] = tabular_dataset.resource_name
 
-        gapic_metadata = json_format.MessageToDict(gapic_dataset._pb.metadata)
+        gapic_metadata = tabular_dataset.to_dict()["metadata"]
         gcs_source_uris = gapic_metadata["inputConfig"]["gcsSource"]["uri"]
 
         assert len(gcs_source_uris) == 1
         assert _TEST_TABULAR_CLASSIFICATION_GCS_SOURCE == gcs_source_uris[0]
         assert (
-            gapic_dataset.metadata_schema_uri
+            tabular_dataset.metadata_schema_uri
             == aiplatform.schema.dataset.metadata.tabular
         )
 

--- a/tests/system/aiplatform/test_dataset.py
+++ b/tests/system/aiplatform/test_dataset.py
@@ -21,7 +21,6 @@ import pytest
 import importlib
 
 from google import auth as google_auth
-from google.protobuf import json_format
 from google.api_core import exceptions
 from google.api_core import client_options
 


### PR DESCRIPTION
This method allows getting the resource metadata as a standard Python dictionary.
Without this method, any user who would want to do this would have to access private fields.