### PR TITLE
 feat: Support uploading local models

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -16,6 +16,8 @@
 #
 import pathlib
 import proto
+import shutil
+import tempfile
 from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 from google.api_core import operation
@@ -2406,3 +2408,276 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         _LOGGER.log_action_completed_against_resource("model", "exported", self)
 
         return json_format.MessageToDict(operation_future.metadata.output_info._pb)
+
+    @staticmethod
+    def upload_xgboost_model_file(
+        model_file_path: str,
+        xgboost_version: Optional[str] = None,
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+        instance_schema_uri: Optional[str] = None,
+        parameters_schema_uri: Optional[str] = None,
+        prediction_schema_uri: Optional[str] = None,
+        explanation_metadata: Optional[explain.ExplanationMetadata] = None,
+        explanation_parameters: Optional[explain.ExplanationParameters] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+        labels: Optional[Dict[str, str]] = None,
+        encryption_spec_key_name: Optional[str] = None,
+        staging_bucket: Optional[str] = None,
+        sync=True,
+    ):
+        # https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers#xgboost
+        XGBOOST_SUPPORTED_VERSIONS = ["0.82", "0.90", "1.1", "1.2", "1.3", "1.4"]
+        XGBOOST_CONTAINER_IMAGE_URI_TEMPLATE = (
+            "{registry}/vertex-ai/prediction/xgboost-{cpu_or_gpu}.{version}:latest"
+        )
+
+        XGBOOST_SUPPORTED_MODEL_FILE_EXTENSIONS = [
+            ".pkl",
+            ".joblib",
+            ".bst",
+        ]
+
+        if xgboost_version is None:
+            # Using the latest version
+            xgboost_version = XGBOOST_SUPPORTED_VERSIONS[-1]
+            _LOGGER.info(f"Using the {xgboost_version} version of XGBoost.")
+
+        if xgboost_version not in XGBOOST_SUPPORTED_VERSIONS:
+            _LOGGER.error(
+                f"XGBoost version {version} is not supported. "
+                f"Supported versions: {XGBOOST_SUPPORTED_VERSIONS}"
+            )
+
+        model_file_path_obj = pathlib.Path(model_file_path)
+        if not model_file_path_obj.is_file():
+            raise ValueError(
+                f"model_file_path path must point to a file: '{model_file_path}'"
+            )
+
+        model_file_extension = model_file_path_obj.suffix
+        if model_file_extension not in XGBOOST_SUPPORTED_MODEL_FILE_EXTENSIONS:
+            _LOGGER.warning(
+                f"Only the following XGBoost model file extensions are currently supported: '{XGBOOST_SUPPORTED_MODEL_FILE_EXTENSIONS}'"
+            )
+            _LOGGER.warning(
+                "Treating the model file as a binary serialized XGBoost Booster."
+            )
+            model_file_extension = ".bst"
+
+        # Preparing model directory
+        prepared_model_dir = tempfile.mkdtemp()
+        prepared_model_file_path = pathlib.Path(prepared_model_dir) / (
+            "model" + model_file_extension
+        )
+        shutil.copy(model_file_path_obj, prepared_model_file_path)
+
+        container_image_uri = XGBOOST_CONTAINER_IMAGE_URI_TEMPLATE.format(
+            registry=_get_container_registry(
+                location or aiplatform.initializer.global_config.location
+            ),
+            cpu_or_gpu="cpu",
+            version=xgboost_version.replace(".", "-"),
+        )
+
+        display_name = display_name or "XGBoost model"
+
+        return aiplatform.Model.upload(
+            serving_container_image_uri=container_image_uri,
+            artifact_uri=prepared_model_dir,
+            display_name=display_name,
+            description=description,
+            instance_schema_uri=instance_schema_uri,
+            parameters_schema_uri=parameters_schema_uri,
+            prediction_schema_uri=prediction_schema_uri,
+            explanation_metadata=explanation_metadata,
+            explanation_parameters=explanation_parameters,
+            project=project,
+            location=location,
+            credentials=credentials,
+            labels=labels,
+            encryption_spec_key_name=encryption_spec_key_name,
+            staging_bucket=staging_bucket,
+            sync=sync,
+        )
+
+    @staticmethod
+    def upload_scikit_learn_model_file(
+        model_file_path: str,
+        sklearn_version: Optional[str] = None,
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+        instance_schema_uri: Optional[str] = None,
+        parameters_schema_uri: Optional[str] = None,
+        prediction_schema_uri: Optional[str] = None,
+        explanation_metadata: Optional[explain.ExplanationMetadata] = None,
+        explanation_parameters: Optional[explain.ExplanationParameters] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+        labels: Optional[Dict[str, str]] = None,
+        encryption_spec_key_name: Optional[str] = None,
+        staging_bucket: Optional[str] = None,
+        sync=True,
+    ):
+        # https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers#scikit-learn
+        SKLEARN_SUPPORTED_VERSIONS = ["0.20", "0.22", "0.23", "0.24"]
+        SKLEARN_CONTAINER_IMAGE_URI_TEMPLATE = (
+            "{registry}/vertex-ai/prediction/sklearn-{cpu_or_gpu}.{version}:latest"
+        )
+        SKLEARN_SUPPORTED_MODEL_FILE_EXTENSIONS = [
+            ".pkl",
+            ".joblib",
+        ]
+
+        if sklearn_version is None:
+            # Using the latest version
+            sklearn_version = SKLEARN_SUPPORTED_VERSIONS[-1]
+            _LOGGER.info(f"Using the {sklearn_version} version of Scikit-learn.")
+
+        if sklearn_version not in SKLEARN_SUPPORTED_VERSIONS:
+            _LOGGER.error(
+                f"Scikit-learn version {version} is not supported. "
+                f"Supported versions: {SKLEARN_SUPPORTED_VERSIONS}"
+            )
+
+        model_file_path_obj = pathlib.Path(model_file_path)
+        if not model_file_path_obj.is_file():
+            raise ValueError(
+                f"model_file_path path must point to a file: '{model_file_path}'"
+            )
+
+        model_file_extension = model_file_path_obj.suffix
+        if model_file_extension not in SKLEARN_SUPPORTED_MODEL_FILE_EXTENSIONS:
+            _LOGGER.warning(
+                f"Only the following Scikit-learn model file extensions are currently supported: '{SKLEARN_SUPPORTED_MODEL_FILE_EXTENSIONS}'"
+            )
+            _LOGGER.warning(
+                "Treating the model file as a pickle serialized Scikit-learn model."
+            )
+            model_file_extension = ".pkl"
+
+        # Preparing model directory
+        prepared_model_dir = tempfile.mkdtemp()
+        prepared_model_file_path = pathlib.Path(prepared_model_dir) / (
+            "model" + model_file_extension
+        )
+        shutil.copy(model_file_path_obj, prepared_model_file_path)
+
+        container_image_uri = SKLEARN_CONTAINER_IMAGE_URI_TEMPLATE.format(
+            registry=_get_container_registry(
+                location or aiplatform.initializer.global_config.location
+            ),
+            cpu_or_gpu="cpu",
+            version=sklearn_version.replace(".", "-"),
+        )
+
+        display_name = display_name or "Scikit-learn model"
+
+        return aiplatform.Model.upload(
+            serving_container_image_uri=container_image_uri,
+            artifact_uri=prepared_model_dir,
+            display_name=display_name,
+            description=description,
+            instance_schema_uri=instance_schema_uri,
+            parameters_schema_uri=parameters_schema_uri,
+            prediction_schema_uri=prediction_schema_uri,
+            explanation_metadata=explanation_metadata,
+            explanation_parameters=explanation_parameters,
+            project=project,
+            location=location,
+            credentials=credentials,
+            labels=labels,
+            encryption_spec_key_name=encryption_spec_key_name,
+            staging_bucket=staging_bucket,
+            sync=sync,
+        )
+
+    @staticmethod
+    def upload_tensorflow_saved_model(
+        saved_model_dir: str,
+        tensorflow_version: Optional[str] = None,
+        use_gpu: bool = False,
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+        instance_schema_uri: Optional[str] = None,
+        parameters_schema_uri: Optional[str] = None,
+        prediction_schema_uri: Optional[str] = None,
+        explanation_metadata: Optional[explain.ExplanationMetadata] = None,
+        explanation_parameters: Optional[explain.ExplanationParameters] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+        labels: Optional[Dict[str, str]] = None,
+        encryption_spec_key_name: Optional[str] = None,
+        staging_bucket: Optional[str] = None,
+        sync=True,
+    ):
+        # https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers#tensorflow
+        TENSORFLOW_SUPPORTED_VERSIONS = [
+            "0.15",
+            "2.1",
+            "2.2",
+            "2.3",
+            "2.4",
+            "2.5",
+            "2.6",
+        ]
+        TENSORFLOW_CONTAINER_IMAGE_URI_TEMPLATE = (
+            "{registry}/vertex-ai/prediction/tf{tf2_or_1}-{cpu_or_gpu}.{version}:latest"
+        )
+
+        if tensorflow_version is None:
+            # Using the latest version
+            tensorflow_version = TENSORFLOW_SUPPORTED_VERSIONS[-1]
+            _LOGGER.info(f"Using the {tensorflow_version} version of Tensorflow.")
+
+        if tensorflow_version not in TENSORFLOW_SUPPORTED_VERSIONS:
+            _LOGGER.error(
+                f"Tensorflow version {version} is not supported. "
+                f"Supported versions: {TENSORFLOW_SUPPORTED_VERSIONS}"
+            )
+
+        container_image_uri = TENSORFLOW_CONTAINER_IMAGE_URI_TEMPLATE.format(
+            registry=_get_container_registry(
+                location or aiplatform.initializer.global_config.location
+            ),
+            tf2_or_1=("2" if tensorflow_version.startswith("2.") else ""),
+            cpu_or_gpu="gpu" if use_gpu else "cpu",
+            version=tensorflow_version.replace(".", "-"),
+        )
+
+        display_name = display_name or "Tensorflow model"
+
+        return aiplatform.Model.upload(
+            serving_container_image_uri=container_image_uri,
+            artifact_uri=saved_model_dir,
+            display_name=display_name,
+            description=description,
+            instance_schema_uri=instance_schema_uri,
+            parameters_schema_uri=parameters_schema_uri,
+            prediction_schema_uri=prediction_schema_uri,
+            explanation_metadata=explanation_metadata,
+            explanation_parameters=explanation_parameters,
+            project=project,
+            location=location,
+            credentials=credentials,
+            labels=labels,
+            encryption_spec_key_name=encryption_spec_key_name,
+            staging_bucket=staging_bucket,
+            sync=sync,
+        )
+
+
+def _get_container_registry(location: Optional[str] = None,) -> str:
+    location = location or "us-"
+    if location.startswith("us-"):
+        return "us-docker.pkg.dev"
+    elif location.startswith("europe-"):
+        return "europe-docker.pkg.dev"
+    elif location.startswith("asia-"):
+        return "asia-docker.pkg.dev"
+    else:
+        raise ValueError(f"Unrecognized location: {location}")

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -2428,6 +2428,120 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         staging_bucket: Optional[str] = None,
         sync=True,
     ):
+        """Uploads a model and returns a Model representing the uploaded Model
+        resource.
+
+        Note: This function is *experimental* and can be changed in the future.
+
+        Example usage::
+
+            my_model = Model.upload_xgboost_model_file(
+                model_file_path="iris.xgboost_model.bst"
+            )
+
+        Args:
+            model_file_path (str): Required. Local file path of the model.
+            xgboost_version (str): Optional. The version of the XGBoost serving container.
+                Supported versions: ["0.82", "0.90", "1.1", "1.2", "1.3", "1.4"].
+                If the version is not specified, the latest version is used.
+            display_name (str):
+                Optional. The display name of the Model. The name can be up to 128
+                characters long and can be consist of any UTF-8 characters.
+            description (str):
+                The description of the model.
+            instance_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the format of a single instance, which
+                are used in
+                ``PredictRequest.instances``,
+                ``ExplainRequest.instances``
+                and
+                ``BatchPredictionJob.input_config``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform. Note: The URI given on output will be immutable
+                and probably different, including the URI scheme, than the
+                one given on input. The output URI will point to a location
+                where the user only has a read access.
+            parameters_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the parameters of prediction and
+                explanation via
+                ``PredictRequest.parameters``,
+                ``ExplainRequest.parameters``
+                and
+                ``BatchPredictionJob.model_parameters``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform, if no parameters are supported it is set to an
+                empty string. Note: The URI given on output will be
+                immutable and probably different, including the URI scheme,
+                than the one given on input. The output URI will point to a
+                location where the user only has a read access.
+            prediction_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the format of a single prediction
+                produced by this Model, which are returned via
+                ``PredictResponse.predictions``,
+                ``ExplainResponse.explanations``,
+                and
+                ``BatchPredictionJob.output_config``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform. Note: The URI given on output will be immutable
+                and probably different, including the URI scheme, than the
+                one given on input. The output URI will point to a location
+                where the user only has a read access.
+            explanation_metadata (explain.ExplanationMetadata):
+                Optional. Metadata describing the Model's input and output for explanation.
+                Both `explanation_metadata` and `explanation_parameters` must be
+                passed together when used. For more details, see
+                `Ref docs <http://tinyurl.com/1igh60kt>`
+            explanation_parameters (explain.ExplanationParameters):
+                Optional. Parameters to configure explaining for Model's predictions.
+                For more details, see `Ref docs <http://tinyurl.com/1an4zake>`
+            project: Optional[str]=None,
+                Project to upload this model to. Overrides project set in
+                aiplatform.init.
+            location: Optional[str]=None,
+                Location to upload this model to. Overrides location set in
+                aiplatform.init.
+            credentials: Optional[auth_credentials.Credentials]=None,
+                Custom credentials to use to upload this model. Overrides credentials
+                set in aiplatform.init.
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to
+                organize your Models.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the model. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Model and all sub-resources of this Model will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
+            staging_bucket (str):
+                Optional. Bucket to stage local model artifacts. Overrides
+                staging_bucket set in aiplatform.init.
+        Returns:
+            model: Instantiated representation of the uploaded model resource.
+        Raises:
+            ValueError: If only `explanation_metadata` or `explanation_parameters`
+                is specified.
+        """
         # https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers#xgboost
         XGBOOST_SUPPORTED_VERSIONS = ["0.82", "0.90", "1.1", "1.2", "1.3", "1.4"]
         XGBOOST_CONTAINER_IMAGE_URI_TEMPLATE = (
@@ -2522,6 +2636,121 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         staging_bucket: Optional[str] = None,
         sync=True,
     ):
+        """Uploads a model and returns a Model representing the uploaded Model
+        resource.
+
+        Note: This function is *experimental* and can be changed in the future.
+
+        Example usage::
+
+            my_model = Model.upload_scikit_learn_model_file(
+                model_file_path="iris.sklearn_model.joblib"
+            )
+
+        Args:
+            model_file_path (str): Required. Local file path of the model.
+            sklearn_version (str):
+                Optional. The version of the Scikit-learn serving container.
+                Supported versions: ["0.20", "0.22", "0.23", "0.24"].
+                If the version is not specified, the latest version is used.
+            display_name (str):
+                Optional. The display name of the Model. The name can be up to 128
+                characters long and can be consist of any UTF-8 characters.
+            description (str):
+                The description of the model.
+            instance_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the format of a single instance, which
+                are used in
+                ``PredictRequest.instances``,
+                ``ExplainRequest.instances``
+                and
+                ``BatchPredictionJob.input_config``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform. Note: The URI given on output will be immutable
+                and probably different, including the URI scheme, than the
+                one given on input. The output URI will point to a location
+                where the user only has a read access.
+            parameters_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the parameters of prediction and
+                explanation via
+                ``PredictRequest.parameters``,
+                ``ExplainRequest.parameters``
+                and
+                ``BatchPredictionJob.model_parameters``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform, if no parameters are supported it is set to an
+                empty string. Note: The URI given on output will be
+                immutable and probably different, including the URI scheme,
+                than the one given on input. The output URI will point to a
+                location where the user only has a read access.
+            prediction_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the format of a single prediction
+                produced by this Model, which are returned via
+                ``PredictResponse.predictions``,
+                ``ExplainResponse.explanations``,
+                and
+                ``BatchPredictionJob.output_config``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform. Note: The URI given on output will be immutable
+                and probably different, including the URI scheme, than the
+                one given on input. The output URI will point to a location
+                where the user only has a read access.
+            explanation_metadata (explain.ExplanationMetadata):
+                Optional. Metadata describing the Model's input and output for explanation.
+                Both `explanation_metadata` and `explanation_parameters` must be
+                passed together when used. For more details, see
+                `Ref docs <http://tinyurl.com/1igh60kt>`
+            explanation_parameters (explain.ExplanationParameters):
+                Optional. Parameters to configure explaining for Model's predictions.
+                For more details, see `Ref docs <http://tinyurl.com/1an4zake>`
+            project: Optional[str]=None,
+                Project to upload this model to. Overrides project set in
+                aiplatform.init.
+            location: Optional[str]=None,
+                Location to upload this model to. Overrides location set in
+                aiplatform.init.
+            credentials: Optional[auth_credentials.Credentials]=None,
+                Custom credentials to use to upload this model. Overrides credentials
+                set in aiplatform.init.
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to
+                organize your Models.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the model. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Model and all sub-resources of this Model will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
+            staging_bucket (str):
+                Optional. Bucket to stage local model artifacts. Overrides
+                staging_bucket set in aiplatform.init.
+        Returns:
+            model: Instantiated representation of the uploaded model resource.
+        Raises:
+            ValueError: If only `explanation_metadata` or `explanation_parameters`
+                is specified.
+        """
         # https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers#scikit-learn
         SKLEARN_SUPPORTED_VERSIONS = ["0.20", "0.22", "0.23", "0.24"]
         SKLEARN_CONTAINER_IMAGE_URI_TEMPLATE = (
@@ -2615,6 +2844,123 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         staging_bucket: Optional[str] = None,
         sync=True,
     ):
+        """Uploads a model and returns a Model representing the uploaded Model
+        resource.
+
+        Note: This function is *experimental* and can be changed in the future.
+
+        Example usage::
+
+            my_model = Model.upload_scikit_learn_model_file(
+                model_file_path="iris.tensorflow_model.SavedModel"
+            )
+
+        Args:
+            saved_model_dir (str): Required.
+                Local directory of the Tensorflow SavedModel.
+            tensorflow_version (str):
+                Optional. The version of the Tensorflow serving container.
+                Supported versions: ["0.15", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"].
+                If the version is not specified, the latest version is used.
+            use_gpu (bool): Whether to use GPU for model serving.
+            display_name (str):
+                Optional. The display name of the Model. The name can be up to 128
+                characters long and can be consist of any UTF-8 characters.
+            description (str):
+                The description of the model.
+            instance_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the format of a single instance, which
+                are used in
+                ``PredictRequest.instances``,
+                ``ExplainRequest.instances``
+                and
+                ``BatchPredictionJob.input_config``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform. Note: The URI given on output will be immutable
+                and probably different, including the URI scheme, than the
+                one given on input. The output URI will point to a location
+                where the user only has a read access.
+            parameters_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the parameters of prediction and
+                explanation via
+                ``PredictRequest.parameters``,
+                ``ExplainRequest.parameters``
+                and
+                ``BatchPredictionJob.model_parameters``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform, if no parameters are supported it is set to an
+                empty string. Note: The URI given on output will be
+                immutable and probably different, including the URI scheme,
+                than the one given on input. The output URI will point to a
+                location where the user only has a read access.
+            prediction_schema_uri (str):
+                Optional. Points to a YAML file stored on Google Cloud
+                Storage describing the format of a single prediction
+                produced by this Model, which are returned via
+                ``PredictResponse.predictions``,
+                ``ExplainResponse.explanations``,
+                and
+                ``BatchPredictionJob.output_config``.
+                The schema is defined as an OpenAPI 3.0.2 `Schema
+                Object <https://tinyurl.com/y538mdwt#schema-object>`__.
+                AutoML Models always have this field populated by AI
+                Platform. Note: The URI given on output will be immutable
+                and probably different, including the URI scheme, than the
+                one given on input. The output URI will point to a location
+                where the user only has a read access.
+            explanation_metadata (explain.ExplanationMetadata):
+                Optional. Metadata describing the Model's input and output for explanation.
+                Both `explanation_metadata` and `explanation_parameters` must be
+                passed together when used. For more details, see
+                `Ref docs <http://tinyurl.com/1igh60kt>`
+            explanation_parameters (explain.ExplanationParameters):
+                Optional. Parameters to configure explaining for Model's predictions.
+                For more details, see `Ref docs <http://tinyurl.com/1an4zake>`
+            project: Optional[str]=None,
+                Project to upload this model to. Overrides project set in
+                aiplatform.init.
+            location: Optional[str]=None,
+                Location to upload this model to. Overrides location set in
+                aiplatform.init.
+            credentials: Optional[auth_credentials.Credentials]=None,
+                Custom credentials to use to upload this model. Overrides credentials
+                set in aiplatform.init.
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to
+                organize your Models.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the model. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Model and all sub-resources of this Model will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
+            staging_bucket (str):
+                Optional. Bucket to stage local model artifacts. Overrides
+                staging_bucket set in aiplatform.init.
+        Returns:
+            model: Instantiated representation of the uploaded model resource.
+        Raises:
+            ValueError: If only `explanation_metadata` or `explanation_parameters`
+                is specified.
+        """
         # https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers#tensorflow
         TENSORFLOW_SUPPORTED_VERSIONS = [
             "0.15",

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -2561,7 +2561,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         if xgboost_version not in XGBOOST_SUPPORTED_VERSIONS:
             _LOGGER.error(
-                f"XGBoost version {version} is not supported. "
+                f"XGBoost version {xgboost_version} is not supported. "
                 f"Supported versions: {XGBOOST_SUPPORTED_VERSIONS}"
             )
 
@@ -2768,7 +2768,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         if sklearn_version not in SKLEARN_SUPPORTED_VERSIONS:
             _LOGGER.error(
-                f"Scikit-learn version {version} is not supported. "
+                f"Scikit-learn version {sklearn_version} is not supported. "
                 f"Supported versions: {SKLEARN_SUPPORTED_VERSIONS}"
             )
 
@@ -2982,7 +2982,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         if tensorflow_version not in TENSORFLOW_SUPPORTED_VERSIONS:
             _LOGGER.error(
-                f"Tensorflow version {version} is not supported. "
+                f"Tensorflow version {tensorflow_version} is not supported. "
                 f"Supported versions: {TENSORFLOW_SUPPORTED_VERSIONS}"
             )
 

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pathlib
 import proto
 from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
@@ -52,6 +53,15 @@ from google.protobuf import json_format
 
 
 _LOGGER = base.Logger(__name__)
+
+
+_SUPPORTED_MODEL_FILE_NAMES = [
+    "model.pkl",
+    "model.joblib",
+    "model.bst",
+    "saved_model.pb",
+    "saved_model.pbtxt",
+]
 
 
 class Prediction(NamedTuple):
@@ -1675,8 +1685,26 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         )
 
         if artifact_uri and not artifact_uri.startswith("gs://"):
+            # Validating the model directory
+            model_dir = pathlib.Path(artifact_uri)
+            if not model_dir.exists():
+                raise ValueError(f"artifact_uri path does not exist: '{artifact_uri}'")
+            if not model_dir.is_dir():
+                raise ValueError(
+                    f"artifact_uri path must be a directory: '{artifact_uri}'"
+                )
+            if not any(
+                (model_dir / file_name).exists()
+                for file_name in _SUPPORTED_MODEL_FILE_NAMES
+            ):
+                raise ValueError(
+                    "artifact_uri directory does not contain any supported model files. "
+                    f"The upload method only supports the following model files: '{_SUPPORTED_MODEL_FILE_NAMES}'"
+                )
+
+            # Uploading the model
             staged_data_uri = utils.stage_local_data_in_gcs(
-                data_path=artifact_uri,
+                data_path=str(model_dir),
                 staging_gcs_dir=staging_bucket,
                 project=project,
                 location=location,

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1471,6 +1471,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         encryption_spec_key_name: Optional[str] = None,
+        staging_bucket: Optional[str] = None,
         sync=True,
     ) -> "Model":
         """Uploads a model and returns a Model representing the uploaded Model
@@ -1604,6 +1605,9 @@ class Model(base.VertexAiResourceNounWithFutureManager):
                 If set, this Model and all sub-resources of this Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
+            staging_bucket (str):
+                Optional. Bucket to stage local model artifacts. Overrides
+                staging_bucket set in aiplatform.init.
         Returns:
             model: Instantiated representation of the uploaded model resource.
         Raises:
@@ -1669,6 +1673,16 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             predict_schemata=model_predict_schemata,
             encryption_spec=encryption_spec,
         )
+
+        if artifact_uri and not artifact_uri.startswith("gs://"):
+            staged_data_uri = utils.stage_local_data_in_gcs(
+                data_path=artifact_uri,
+                staging_gcs_dir=staging_bucket,
+                project=project,
+                location=location,
+                credentials=credentials,
+            )
+            artifact_uri = staged_data_uri
 
         if artifact_uri:
             managed_model.artifact_uri = artifact_uri

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -568,7 +568,7 @@ def _timestamped_copy_to_gcs(
     blob_path = "-".join(["aiplatform", timestamp, local_file_name])
 
     if gcs_blob_prefix:
-        blob_path = "/".join([gcs_blob_prefix, blob_path, local_file_name])
+        blob_path = "/".join([gcs_blob_prefix, blob_path])
 
     # TODO(b/171202993) add user agent
     client = storage.Client(project=project, credentials=credentials)
@@ -665,31 +665,33 @@ def stage_local_data_in_gcs(
     if not staging_gcs_dir:
         project = project or initializer.global_config.project
         location = location or initializer.global_config.location
-        staging_gcs_dir = "gs://" + project + "-staging"
         # Creating the bucket if it does not exist.
         # Currently we only do this when staging_gcs_dir is not specified.
-        staging_bucket_name, _ = extract_bucket_and_prefix_from_gcs_path(staging_gcs_dir)
+        staging_bucket_name = project + "-staging"
         client = storage.Client(project=project, credentials=credentials)
         staging_bucket = storage.Bucket(client=client, name=staging_bucket_name)
         if not staging_bucket.exists():
+            _logger.info(f'Creating staging GCS bucket "{staging_bucket_name}"')
             staging_bucket = client.create_bucket(
-                bucket_or_name=staging_bucket,
-                project =project ,
-                location=location,
+                bucket_or_name=staging_bucket, project=project, location=location,
             )
+        staging_gcs_dir = "gs://" + staging_bucket_name
 
-    staging_root_dir = staging_gcs_dir.rstrip("/") + "/vertex_ai_auto_staging/"
+    timestamp = datetime.datetime.now().isoformat(sep="-", timespec="milliseconds")
+    staging_gcs_subdir = (
+        staging_gcs_dir.rstrip("/") + "/vertex_ai_auto_staging/" + timestamp
+    )
 
-    if data_path_obj.is_dir():
-        raise NotImplementedError("Uploading directories is not supported yet.")
+    staged_data_uri = staging_gcs_subdir
+    if data_path_obj.is_file():
+        staged_data_uri = staging_gcs_subdir + "/" + data_path_obj.name
 
-    _timestamped_gcs_dir
-
-    staged_data_uri = _timestamped_copy_to_gcs(
-        local_file_path=data_path,
-        gcs_dir=staging_root_dir,
-        project=project or initializer.global_config.project,
-        credentials=credentials or initializer.global_config.credentials,
+    _logger.info(f'Uploading "{data_path}" to "{staged_data_uri}"')
+    upload_to_gcs(
+        source_path=data_path,
+        destination_uri=staged_data_uri,
+        project=project,
+        credentials=credentials,
     )
 
     return staged_data_uri

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -565,7 +565,7 @@ def _timestamped_copy_to_gcs(
     blob_path = "-".join(["aiplatform", timestamp, local_file_name])
 
     if gcs_blob_prefix:
-        blob_path = "/".join([gcs_blob_prefix, blob_path])
+        blob_path = "/".join([gcs_blob_prefix, blob_path, local_file_name])
 
     # TODO(b/171202993) add user agent
     client = storage.Client(project=project, credentials=credentials)
@@ -575,3 +575,66 @@ def _timestamped_copy_to_gcs(
 
     gcs_path = "".join(["gs://", "/".join([blob.bucket.name, blob.name])])
     return gcs_path
+
+
+def stage_local_data_in_gcs(
+    data_path: str,
+    staging_gcs_dir: Optional[str] = None,
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+    credentials: Optional[auth_credentials.Credentials] = None,
+) -> str:
+    """Stages a local data in GCS.
+
+    The file copied to GCS is the name of the local file prepended with an
+    "aiplatform-{timestamp}-" string.
+
+    Args:
+        data_path: Required. Path of the local data to copy to GCS.
+        staging_gcs_dir:
+            Optional. Google Cloud Storage bucket to be used for data staging.
+        project: Optional. Google Cloud Project that contains the staging bucket.
+        location: Optional. Google Cloud location to use for the staging bucket.
+        credentials: The custom credentials to use when making API calls.
+            If not provided, default credentials will be used.
+
+    Returns:
+        Google Cloud Storage URI of the staged data.
+    """
+    data_path_obj = pathlib.Path(data_path)
+
+    if not data_path_obj.exists():
+        raise RuntimeError(f"Local data does not exist: data_path='{data_path}'")
+
+    staging_gcs_dir = staging_gcs_dir or initializer.global_config.staging_bucket
+    if not staging_gcs_dir:
+        project = project or initializer.global_config.project
+        location = location or initializer.global_config.location
+        staging_gcs_dir = "gs://" + project + "-staging"
+        # Creating the bucket if it does not exist.
+        # Currently we only do this when staging_gcs_dir is not specified.
+        staging_bucket_name, _ = extract_bucket_and_prefix_from_gcs_path(staging_gcs_dir)
+        client = storage.Client(project=project, credentials=credentials)
+        staging_bucket = storage.Bucket(client=client, name=staging_bucket_name)
+        if not staging_bucket.exists():
+            staging_bucket = client.create_bucket(
+                bucket_or_name=staging_bucket,
+                project =project ,
+                location=location,
+            )
+
+    staging_root_dir = staging_gcs_dir.rstrip("/") + "/vertex_ai_auto_staging/"
+
+    if data_path_obj.is_dir():
+        raise NotImplementedError("Uploading directories is not supported yet.")
+
+    _timestamped_gcs_dir
+
+    staged_data_uri = _timestamped_copy_to_gcs(
+        local_file_path=data_path,
+        gcs_dir=staging_root_dir,
+        project=project or initializer.global_config.project,
+        credentials=credentials or initializer.global_config.credentials,
+    )
+
+    return staged_data_uri

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -18,6 +18,7 @@
 
 import abc
 import datetime
+import glob
 import pathlib
 from collections import namedtuple
 import logging
@@ -55,6 +56,8 @@ from google.cloud.aiplatform.compat.services import (
 from google.cloud.aiplatform.compat.types import (
     accelerator_type as gca_accelerator_type,
 )
+
+_logger = logging.getLogger(__name__)
 
 VertexAiServiceClient = TypeVar(
     "VertexAiServiceClient",
@@ -575,6 +578,58 @@ def _timestamped_copy_to_gcs(
 
     gcs_path = "".join(["gs://", "/".join([blob.bucket.name, blob.name])])
     return gcs_path
+
+
+def upload_to_gcs(
+    source_path: str,
+    destination_uri: str,
+    project: Optional[str] = None,
+    credentials: Optional[auth_credentials.Credentials] = None,
+):
+    """Uploads local files to GCS.
+
+    After upload the `destination_uri` will contain the same data as the `source_path`.
+
+    Args:
+        source_path: Required. Path of the local data to copy to GCS.
+        destination_uri: Required. GCS URI where the data should be uploaded.
+        project: Optional. Google Cloud Project that contains the staging bucket.
+        credentials: The custom credentials to use when making API calls.
+            If not provided, default credentials will be used.
+    """
+    source_path_obj = pathlib.Path(source_path)
+    if not source_path_obj.exists():
+        raise RuntimeError(f"Source path does not exist: {source_path}")
+
+    storage_client = storage.Client(project=project, credentials=credentials)
+    if source_path_obj.is_dir():
+        source_file_paths = glob.glob(
+            pathname=str(source_path_obj / "**"), recursive=True
+        )
+        for source_file_path in source_file_paths:
+            source_file_path_obj = pathlib.Path(source_file_path)
+            if source_file_path_obj.is_dir():
+                continue
+            source_file_relative_path_obj = source_file_path_obj.relative_to(
+                source_path_obj
+            )
+            source_file_relative_posix_path = source_file_relative_path_obj.as_posix()
+            destination_file_uri = (
+                destination_uri.rstrip("/") + "/" + source_file_relative_posix_path
+            )
+            _logger.debug(f'Uploading "{source_file_path}" to "{destination_file_uri}"')
+            destination_blob = storage.Blob.from_string(
+                destination_file_uri, client=storage_client
+            )
+            destination_blob.upload_from_filename(filename=source_file_path)
+    else:
+        source_file_path = source_path
+        destination_file_uri = destination_uri
+        _logger.debug(f'Uploading "{source_file_path}" to "{destination_file_uri}"')
+        destination_blob = storage.Blob.from_string(
+            destination_file_uri, client=storage_client
+        )
+        destination_blob.upload_from_filename(filename=source_file_path)
 
 
 def stage_local_data_in_gcs(


### PR DESCRIPTION
Added framework-specific model uploaders for XGBoost, Scikit-learn and Tensorflow

This PR adds framework-specific upload functions to the `Model` class:

* `upload_scikit_learn_model_file`
* `upload_xgboost_model_file`
* `upload_tensorflow_saved_model`

Here is what these functions do for the user:
* Validate model file
* Validate framework version or choose default one
* Construct model display_name
* Create directory for the model (every uploaded Vertex model must be a directory)
* Rename the model file (Vertex AI only supports a small strict list of file names)
* Create staging GCS bucket if needed
* Upload the model directory to a unique location in the staging GCS bucket
* Construct serving container URI based on framework, version, CPU vs. GPU, region etc
* Upload the model

This PR also augments the `Model.upload` function such that when `artifact_uri` points to a local model file or directory, the model is automatically staged in Google Cloud Storage as required by the `Model.upload` API. The `Model.upload` function now also checks the model files for correctness.

This change does not add any new dependencies.

Example usage:

```python
model = aiplatform.Model.upload_scikit_learn_model_file("iris.sklearn_model.joblib")
```

```python
model = aiplatform.Model.upload_xgboost_model_file("iris.xgboost_model.bin")
```

```python
model = aiplatform.Model.upload_tensorflow_saved_model("iris.tensorflow_model.SavedModel")
```

Prediction example:
```python
model = aiplatform.Model.upload_scikit_learn_model_file("iris.sklearn_model.pkl")
endpoint = model.deploy(machine_type="n1-standard-2")
endpoint.predict(instances=[[1, 2, 3, 4]])
```
Output:
```
INFO:google.cloud.aiplatform.models:Using the 0.24 version of Scikit-learn.
INFO:google.cloud.aiplatform.utils:Uploading "/tmp/tmpagz_4y34" to "gs://avolkov-31337-staging/vertex_ai_auto_staging/2021-10-18-19:10:36.387"
INFO:google.cloud.aiplatform.models:Creating Model
INFO:google.cloud.aiplatform.models:Create Model backing LRO: projects/140626129697/locations/us-central1/models/9131602398354079744/operations/3090562396373123072
INFO:google.cloud.aiplatform.models:Model created. Resource name: projects/140626129697/locations/us-central1/models/9131602398354079744
INFO:google.cloud.aiplatform.models:To use this Model in another session:
INFO:google.cloud.aiplatform.models:model = aiplatform.Model('projects/140626129697/locations/us-central1/models/9131602398354079744')
INFO:google.cloud.aiplatform.models:Creating Endpoint
INFO:google.cloud.aiplatform.models:Create Endpoint backing LRO: projects/140626129697/locations/us-central1/endpoints/6185702884286398464/operations/802733785668911104
INFO:google.cloud.aiplatform.models:Endpoint created. Resource name: projects/140626129697/locations/us-central1/endpoints/6185702884286398464
INFO:google.cloud.aiplatform.models:To use this Endpoint in another session:
INFO:google.cloud.aiplatform.models:endpoint = aiplatform.Endpoint('projects/140626129697/locations/us-central1/endpoints/6185702884286398464')
INFO:google.cloud.aiplatform.models:Deploying model to Endpoint : projects/140626129697/locations/us-central1/endpoints/6185702884286398464
INFO:google.cloud.aiplatform.models:Deploy Endpoint model backing LRO: projects/140626129697/locations/us-central1/endpoints/6185702884286398464/operations/8087869132894109696
INFO:google.cloud.aiplatform.models:Endpoint model deployed. Resource name: projects/140626129697/locations/us-central1/endpoints/6185702884286398464
Prediction(predictions=[2.0], deployed_model_id='2568679064810291200', explanations=None)
```
